### PR TITLE
fix plugins volume

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+# password mysql admin et jeedom
+MYSQL_PASSWORD=jeedom

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+plugins

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Documentation d’utilisation
 
+Prérequis: il faut avoir installé git + docker + compose + make
+`apt install make`
+
 ## 1. Préparation de l’environnement
 
 1. **Cloner ce dépôt** (si ce n’est pas déjà fait) :

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,6 @@ services:
       - "--interactive_timeout=600"
     volumes:
       - v_ondilo_jeedom_db:/var/lib/mysql
-      - ./plugins:/plugins-src
     restart: always
     environment:
       - MYSQL_ROOT_PASSWORD=${MYSQL_PASSWORD}
@@ -36,6 +35,7 @@ services:
     container_name: ondilo_jeedom_http
     volumes:
       - v_ondilo_jeedom_http:/var/www/html
+      - ./plugins:/plugins-srv
     tmpfs:
       - /tmp/jeedom
     ports:


### PR DESCRIPTION
Dans docker-compose tu avais mis le volume /plugins sur la db au lieu de jeedom.
J'ai donc corrigé, le script intall-plugins voit mon plugin mais je me trouve avec une nouvelle erreur maintenant:

```
Lancement` de /init-scripts/install-plugins.sh
Création du lien symbolique.
Changement de propriétaire et de permissions.
Vérification du plugin : /var/www/html/plugins/openai
Installation du plugin : openai
/init-scripts/install-plugins.sh: 20: jeecli: not found
```

add .gitignore pour ne pas commit les plugins/*
add .env pour une valeur par défaut de mysql_password